### PR TITLE
Add updating status of BecauseOfs when running scenarios

### DIFF
--- a/Source/TheAviator/flights/FlightReporter.ts
+++ b/Source/TheAviator/flights/FlightReporter.ts
@@ -4,15 +4,77 @@
 import { IFlightReporter } from './IFlightReporter';
 import { ScenarioResult } from './reporting';
 import { Flight } from './Flight';
-import { Scenario, ScenarioEnvironment } from '../gherkin';
+import { Scenario, ScenarioEnvironment, RunState, BecauseOf } from '../gherkin';
 
 import chalk from 'chalk';
+import { merge, Observable } from 'rxjs';
+import { Transform, TransformCallback } from 'stream';
+import { Console } from 'console';
+
+class NewlineCountingStream extends Transform {
+    newlines: number = 0;
+
+    _transform(chunk: any, encoding: BufferEncoding, callback: TransformCallback) {
+        const chunkNewlines = (chunk.toString().match(/\n/g) || []).length as number;
+        this.newlines += chunkNewlines;
+        this.push(chunk, encoding);
+        callback();
+    }
+}
+
+class NewlineCounter {
+    readonly _stream: NewlineCountingStream;
+
+    constructor() {
+        this._stream = new NewlineCountingStream();
+        this._stream.pipe(process.stdout);
+    }
+
+    get console(): Console {
+        return new Console(this._stream);
+    }
+
+    get newlines(): number {
+        return this._stream.newlines;
+    }
+
+    destroy() {
+        this._stream.unpipe()
+        this._stream.destroy();
+    }
+}
+
+type OverwritingConsoleRendererCallback = (console: Console) => void;
+
+class OverwritingConsoleRenderer {
+    _previousLines: number = 0;
+    readonly _callback: OverwritingConsoleRendererCallback;
+
+    constructor(callback: OverwritingConsoleRendererCallback) {
+        this._callback = callback;
+    }
+
+    subscribeTo(...observables: Observable<any>[]) {
+        this.render();
+        merge(...observables).subscribe(() => {
+            this.render();
+        });
+    }
+    
+    private render() {
+        process.stdout.write(`\x1B[${this._previousLines}A`);
+        const counter = new NewlineCounter();
+        this._callback(counter.console);
+        this._previousLines = counter.newlines;
+        counter.destroy();
+    }
+}
 
 export class FlightReporter implements IFlightReporter {
     observe(flight: Flight): void {
-        flight.scenario.subscribe(this.outputScenario);
-        flight.environment.subscribe(this.outputEnvironment);
-        flight.recorder.scenarioResult.subscribe(this.outputScenarioResult);
+        flight.scenario.subscribe(scenario => this.outputScenario(scenario));
+        flight.environment.subscribe(environment => this.outputEnvironment(environment));
+        flight.recorder.scenarioResult.subscribe(result => this.outputScenarioResult(result));
     }
 
     private outputEnvironment(environment: ScenarioEnvironment) {
@@ -32,15 +94,22 @@ export class FlightReporter implements IFlightReporter {
             return;
         }
 
-        console.log('\n');
-        console.log(`Given: ${chalk.bold(scenario.contextName)}\n`);
-        console.log(`Feature: ${chalk.bold(scenario.specification.feature.name)}\n`);
-        console.log(`Scenario: ${chalk.bold(scenario.name)}`);
-        console.log(`  when ${scenario.specification.when.name}`);
+        const renderer = new OverwritingConsoleRenderer((console) => {
+            console.log('\n');
+            console.log(`Given: ${chalk.bold(scenario.contextName)}\n`);
+            console.log(`Feature: ${chalk.bold(scenario.specification.feature.name)}\n`);
+            console.log(`Scenario: ${chalk.bold(scenario.name)}`);
+            console.log(` ${this.becauseOfStatusIcon(scenario.specification.when)} when ${scenario.specification.when.name}`);
 
-        for (const and of scenario.specification.ands) {
-            console.log(`   ${chalk.italic('and')} ${and.name}`);
-        }
+            for (const and of scenario.specification.ands) {
+                console.log(` ${this.becauseOfStatusIcon(and)} ${chalk.italic('and')} ${and.name}`);
+            }
+        });
+        renderer.subscribeTo(scenario.specification.when.status.state, ...scenario.specification.ands.map(_ => _.status.state));
+    }
+
+    private becauseOfStatusIcon(becauseOf: BecauseOf): string {
+        return becauseOf.status.state.value == RunState.Completed ? '✔' : ' ';
     }
 
     private outputScenarioResult(scenarioResult: ScenarioResult) {

--- a/Source/TheAviator/gherkin/BecauseOf.ts
+++ b/Source/TheAviator/gherkin/BecauseOf.ts
@@ -3,19 +3,25 @@
 
 import { ScenarioFor } from './ScenarioFor';
 import { ScenarioContext } from './ScenarioContext';
+import { RunStatus } from './RunStatus';
 
 export class BecauseOf {
     static nothing: BecauseOf = new BecauseOf('nothing', () => { });
 
     readonly name: string;
     readonly method: Function;
+    readonly status: RunStatus;
 
     constructor(name: string, method: Function) {
         this.name = name;
         this.method = method;
+        this.status = new RunStatus();
     }
 
     async invoke(scenarioFor: ScenarioFor<ScenarioContext>): Promise<void> {
+        this.status.running();
         await this.method.apply(scenarioFor);
+        this.status.completed();
     }
 }
+

--- a/Source/TheAviator/gherkin/RunStatus.ts
+++ b/Source/TheAviator/gherkin/RunStatus.ts
@@ -1,0 +1,51 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { BehaviorSubject } from "rxjs";
+
+export enum RunState {
+    None = 'none',
+    Queued = 'queued',
+    Running = 'running',
+    Completed = 'completed'
+}
+
+export class RunStatus {
+    _state : BehaviorSubject<RunState>;
+    _started? : Date;
+    _completed? : Date;
+    _duration : BehaviorSubject<number>;
+    _timer? : NodeJS.Timeout;
+
+    constructor() {
+        this._state = new BehaviorSubject<RunState>(RunState.None);
+        this._duration = new BehaviorSubject<number>(0);
+    }
+
+    get state(): BehaviorSubject<RunState> {
+        return this._state;
+    }
+
+    queued() {
+        this._state.next(RunState.Queued);
+    }
+
+    running() {
+        this._state.next(RunState.Running);
+        this._started = new Date();
+        this._timer = setInterval(() => {
+            const milliseconds = new Date().valueOf() - this._started!.valueOf();
+            this._duration.next(milliseconds/1000);
+        }, 100);
+    }
+
+    completed() {
+        this._state.next(RunState.Completed);
+        this._state.complete();
+        this._completed = new Date();
+        clearInterval(this._timer!);
+        const milliseconds = this._completed!.valueOf() - this._started!.valueOf();
+        this._duration.next(milliseconds/1000);
+        this._duration.complete();
+    }
+}

--- a/Source/TheAviator/gherkin/SpecificationRunner.ts
+++ b/Source/TheAviator/gherkin/SpecificationRunner.ts
@@ -16,6 +16,11 @@ export class SpecificationRunner implements ISpecificationRunner {
             await given.invoke(scenarioFor);
         }
 
+        specification.when.status.queued();
+        for (const and of specification.ands) {
+            and.status.queued();
+        }
+
         await specification.when.invoke(scenarioFor);
 
         for (const and of specification.ands) {

--- a/Source/TheAviator/gherkin/index.ts
+++ b/Source/TheAviator/gherkin/index.ts
@@ -28,3 +28,4 @@ export * from './SpecificationRunner';
 export * from './Then';
 export * from './ThenIsNotAMethod';
 export * from './ThenResult';
+export * from './RunStatus';


### PR DESCRIPTION
It's not really pretty, but it works :)

The `OverwritingConsoleRenderer` should probably get a new name, and be placed somewhere else where it could potentially be re-used elsewhere.

The `RunStatus` could also use some love, and potentially could be used on other components as well that we would like to monitor the status of.

We could also print the running time of each BecauseOf, but that requires a bit more clearing of the console. Right now each line has the exact same length every time it is printed, which makes things easy.